### PR TITLE
Fix release badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Schulstick Portal App
-![Release Workflow](https://github.com/fsfw-dresden/schulstick-portal/actions/workflows/release.yml/badge.svg)
+![Release Workflow](https://github.com/fsfw-dresden/schulstick-portal/actions/workflows/release.yml/badge.svg?event=push)
 
 An open educational portal app integrated into the "Schulstick" free software platform, designed to facilitate IT competency through interactive learning with complex computer programs. The project aims to promote interest in STEM subjects and ensure confident, curious, and sovereign handling of IT.
 


### PR DESCRIPTION
Unclear what the default event type for the badge is, but `push` seems to work..

Docs at https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows